### PR TITLE
[Bugfix] When execute the script "pip-diff", occur Error "ImportError: No module named 'pip.index'".

### DIFF
--- a/bin/pip-diff
+++ b/bin/pip-diff
@@ -12,8 +12,12 @@ Options:
 """
 import os
 from docopt import docopt
-from pip.req import parse_requirements
-from pip.index import PackageFinder
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.index import PackageFinder
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.index import PackageFinder
 from pip._vendor.requests import session
 
 requests = session()


### PR DESCRIPTION
======[Basic Info]======
=[Bug Info]=:
When execute the script "pip-diff", occur Error "ImportError: No module named 'pip.index'".
=[Bugfix Solution]=:
This question is caused by the new version of "pip"(>10.0) modifying the directory structure. and there is a dir named "_internal". So add a logical code to solve it.

======[Bugfix Test Result]======
=[Bug Running Log as following]=

F:\0Devin_2018\CodeProject\Python\PursuitSmallCode\venv\Scripts\python.exe "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\pydevd.py" --multiproc --qt-support=auto --client 127.0.0.1 --port 50787 --file F:/0Devin_2018/CodeProject/Python/pip-pop/bin/pip-diff --stale ..\tests\test-requirements.txt ..\tests\test-requirements2.txt
pydev debugger: process 5032 is connecting

Connected to pydev debugger (build 181.5087.37)
Traceback (most recent call last):
  File "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\pydevd.py", line 1664, in <module>
    main()
  File "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\pydevd.py", line 1658, in main
    globals = debugger.run(setup['file'], None, None, is_module)
  File "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\pydevd.py", line 1068, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\_pydev_imps\_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "F:/0Devin_2018/CodeProject/Python/pip-pop/bin/pip-diff", line 23, in <module>
    from pip.req import parse_requirements
ImportError: No module named 'pip.req'

=[Bugfix Running Result as following]=
F:\0Devin_2018\CodeProject\Python\PursuitSmallCode\venv\Scripts\python.exe "F:\Program Files\PyCharm Community Edition 2018.1.4\helpers\pydev\pydevd.py" --multiproc --qt-support=auto --client 127.0.0.1 --port 50780 --file F:/0Devin_2018/CodeProject/Python/pip-pop/bin/pip-diff --stale ..\tests\test-requirements.txt ..\tests\test-requirements2.txt
pydev debugger: process 5576 is connecting

Connected to pydev debugger (build 181.5087.37)
cffi
django

Process finished with exit code 0
=========================================

Signed-off-by: Devin <huhaichaotd@139.com>